### PR TITLE
Only proxy non-https images

### DIFF
--- a/src/FormatImages.php
+++ b/src/FormatImages.php
@@ -45,7 +45,9 @@ class FormatImages
     {
         if ((bool) $this->settings->get('fof-secure-https.proxy')) {
             $xml = Utils::replaceAttributes($xml, 'IMG', function ($attributes) {
-                $attributes['src'] = $this->url->to('api')->route('fof.secure-https.imgurl').'?imgurl='.urlencode($attributes['src']);
+                if (!preg_match('/^https:\/\//', $attributes['src'])) {
+                    $attributes['src'] = $this->url->to('api')->route('fof.secure-https.imgurl').'?imgurl='.urlencode($attributes['src']);
+                }
 
                 return $attributes;
             });


### PR DESCRIPTION
e.g imgur blocks hetzner IPs with HTTP/429, but already is https anyway

<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Don't use proxying for pictures which are already served using https

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).

**Required changes:**

- [ ] Related [Flarum core extension PR's](https://github.com/flarum/core/pulls): (Omit this section if irrelevant)
